### PR TITLE
feat: allow multiple simultaneous clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,21 @@ for ; ; <-ticker.C {
    go run ./cmd/server
    ```
 
-3. Run `n` clients (`n` > 1 is experimental):
+3. In the server logs, there will be a line similar to the one below that
+   telling you what address the server is bound to:
+
+   ```
+	 11:10:53 INF bound udp/mcp listener address=[ADDRESS]
+	 ```
+
+	 Take note of `[ADDRESS]`.
+
+3. Run the following. Replace `<n>` with the number of clients you'd like to
+   run and also replace `[ADDRESS]` with the one you took note of in the
+   previous step.
 
    ```bash
-   ./spawn_clients.sh <n> # replace <n> with the desired number of clients
+   ./spawn_clients.sh <n> -remote=[ADDRESS]
    ```
 
 [ebitengine_install]: https://ebitengine.org/en/documents/install

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,7 +35,7 @@ func main() {
 	}()
 
 	ebiten.SetWindowTitle("Multiplayer - Simulation")
-	ebiten.SetTPS(15)
+	ebiten.SetTPS(10)
 	err = ebiten.RunGame(sim)
 	if err != nil {
 		slog.Error("failed to run simulation as an ebiten game", "error", err)

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -85,7 +85,23 @@ func (g *Game) Update() error {
 		return nil
 	}
 
-	g.state.Update(dt, input)
+	data, err = g.sess.Receive(ctx)
+	if errors.Is(err, mcp.ErrClosed) {
+		return ebiten.Termination
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	if err != nil {
+		slog.Warn("failed to receive state", "error", err)
+		return nil
+	}
+	err = g.state.UnmarshalBinary(data)
+	if err != nil {
+		slog.Warn("failed to unmarshal state", "error", err)
+		return nil
+	}
+
 	return nil
 }
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -72,7 +72,6 @@ func (g *Game) snapshotLoop() {
 		}
 		index := binary.BigEndian.Uint32(data)
 		if index <= g.lastStateIndex {
-			slog.Debug("dropped old state", "index", index, "current", g.lastStateIndex)
 			continue
 		}
 
@@ -162,9 +161,6 @@ func (g *Game) Update() error {
 		// prev                  next     now
 		t := now.Sub(g.nextSnapshot.t).Seconds() / g.nextSnapshot.t.Sub(g.prevSnapshot.t).Seconds()
 
-		if t > 1 {
-			// slog.Debug("times", "t", t) // t gets high when multiple clients
-		}
 		g.state = g.prevSnapshot.s.Lerp(g.nextSnapshot.s, t)
 	}
 	g.snapshotLock.Unlock()

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -68,6 +68,7 @@ func (g *Game) Update() error {
 		Right: ebiten.IsKeyPressed(ebiten.KeyL),
 	}
 
+	// TODO: use a buffer for sending inputs to ensure order and reliability
 	data, err := input.MarshalBinary()
 	if err != nil {
 		slog.Warn("failed to marshal input", "error", err)
@@ -85,6 +86,19 @@ func (g *Game) Update() error {
 		return nil
 	}
 
+	// TODO: use an interpolation buffer to prevent jitter
+	//
+	// From https://gafferongames.com/post/snapshot_interpolation
+	// > Now for the trick with snapshots. What we do is instead of
+	// > immediately rendering snapshot data received is that we buffer
+	// > snapshots for a short amount of time in an interpolation buffer. This
+	// > interpolation buffer holds on to snapshots for a period of time such
+	// > that you have not only the snapshot you want to render but also,
+	// > statistically speaking, you are very likely to have the next snapshot
+	// > as well. Then as the right side moves forward in time we interpolate
+	// > between the position and orientation for the two slightly delayed
+	// > snapshots providing the illusion of smooth movement. In effect, we’ve
+	// > traded a small amount of added latency for smoothness.
 	data, err = g.sess.Receive(ctx)
 	if errors.Is(err, mcp.ErrClosed) {
 		return ebiten.Termination

--- a/internal/mcp/listener.go
+++ b/internal/mcp/listener.go
@@ -244,6 +244,7 @@ func (ln *Listener) Broadcast(ctx context.Context, data []byte) error {
 	}
 
 	for numSent := 0; numSent < numSessions; numSent++ {
+		// TODO: will the following line panic when a session closes?
 		chosenIdx, _, open := reflect.Select(cases)
 		if !open {
 			switch chosenIdx {
@@ -251,8 +252,6 @@ func (ln *Listener) Broadcast(ctx context.Context, data []byte) error {
 				return ErrClosed
 			case caseCtx:
 				return ctx.Err()
-			default:
-				continue
 			}
 		}
 		cases[chosenIdx].Chan = reflect.Value{}

--- a/internal/mcp/listener.go
+++ b/internal/mcp/listener.go
@@ -477,6 +477,15 @@ func (sess *Session) Receive(ctx context.Context) ([]byte, error) {
 	}
 }
 
+func (sess *Session) TryReceive() ([]byte, bool) {
+	select {
+	case data := <-sess.inbox:
+		return data, true
+	default:
+		return nil, false
+	}
+}
+
 func (sess *Session) Send(ctx context.Context, data []byte) error {
 	select {
 	case <-sess.die:
@@ -485,6 +494,15 @@ func (sess *Session) Send(ctx context.Context, data []byte) error {
 		return ctx.Err()
 	case sess.outbox <- data:
 		return nil
+	}
+}
+
+func (sess *Session) TrySend(data []byte) bool {
+	select {
+	case sess.outbox <- data:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/simulation/simulation.go
+++ b/internal/simulation/simulation.go
@@ -103,5 +103,23 @@ func (sim *Simulation) Update() error {
 	}
 
 	sim.state.Update(dt, input)
+
+	data, err = sim.state.MarshalBinary()
+	if err != nil {
+		slog.Warn("failed to marshal state", "error", err)
+		return nil
+	}
+	err = sim.sess.Send(ctx, data)
+	if errors.Is(err, mcp.ErrClosed) {
+		return ebiten.Termination
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	if err != nil {
+		slog.Warn("failed to send state", "error", err)
+		return nil
+	}
+
 	return nil
 }

--- a/internal/simulation/simulation.go
+++ b/internal/simulation/simulation.go
@@ -105,6 +105,8 @@ func (sim *Simulation) Update() error {
 	ctx, cancel := context.WithTimeout(context.Background(), dt)
 	defer cancel()
 
+	// collect data and then process it to reduce the duration at which the
+	// lock is held.
 	var inputDatas [][]byte
 	sim.sessionLock.Lock()
 	for _, sess := range sim.sessions {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -46,6 +46,13 @@ type State struct {
 	House House
 }
 
+func (s State) Lerp(other State, t float64) State {
+	s.House.Trans = s.House.Trans.Lerp(other.House.Trans, t)
+	s.House.Vel = s.House.Vel.Lerp(other.House.Vel, t)
+	s.House.Accel = s.House.Accel.Lerp(other.House.Accel, t)
+	return s
+}
+
 const HouseSize = 3 * Vec2Size
 
 type House struct {
@@ -57,6 +64,23 @@ type House struct {
 const Vec2Size = 16
 
 type Vec2 struct{ X, Y float64 }
+
+func lerp(a, b, t float64) float64 {
+	if t <= 0 {
+		return a
+	}
+	if t >= 1 {
+		return b
+	}
+
+	return a + (b-a)*t
+}
+
+func (v Vec2) Lerp(other Vec2, t float64) Vec2 {
+	v.X = lerp(v.X, other.X, t)
+	v.Y = lerp(v.Y, other.Y, t)
+	return v
+}
 
 func (v Vec2) Add(other Vec2) Vec2 {
 	v.X += other.X

--- a/spawn_clients.sh
+++ b/spawn_clients.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-n="${1:-1}"
+n="$1"
+shift
 
-for i in $(seq $n); do
-  go run ./cmd/client &
+for i in $(seq "$n"); do
+  go run ./cmd/client "$@" &
 done
 
 wait


### PR DESCRIPTION
Synchronizes state across (reasonably) many clients with **interpolation** and **order reliability**.

---

### Todos for future PRs

- Buffer inputs on clients to ensure reliability and order.
- Think about a better model to send and receive messages of multiple types, potentially from multiple sessions (server only).